### PR TITLE
Fix set private ip address for machine with multiple network interfaces 

### DIFF
--- a/cloudstack.go
+++ b/cloudstack.go
@@ -442,7 +442,11 @@ func (d *Driver) Create() error {
 	if d.PrivateInterfaceIndex >= len(d.NetworkID) {
 		return fmt.Errorf("Private interface index out of bound for network id list")
 	}
-	d.PrivateIP = vm.Nic[d.PrivateInterfaceIndex].Ipaddress
+	for _, nic := range vm.Nic {
+		if nic.Networkid == d.NetworkID[d.PrivateInterfaceIndex] {
+			d.PrivateIP = nic.Ipaddress
+		}
+	}
 	if d.NetworkType == "Basic" {
 		d.PublicIP = d.PrivateIP
 	}

--- a/cloudstack.go
+++ b/cloudstack.go
@@ -445,6 +445,7 @@ func (d *Driver) Create() error {
 	for _, nic := range vm.Nic {
 		if nic.Networkid == d.NetworkID[d.PrivateInterfaceIndex] {
 			d.PrivateIP = nic.Ipaddress
+			break
 		}
 	}
 	if d.NetworkType == "Basic" {


### PR DESCRIPTION
When machine has multiple network interfaces, returned JSON from cloudstack is not deterministic for NIC order. This PR compares each returned network interface on created machine with previous defined network id as private, instead relies on slice index.